### PR TITLE
Feature/istio default profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help: ## Display help
 	awk \
 	  'BEGIN { \
 	    FS = ":.*##"; printf "\nUsage:\n  make \033[36m[TARGET] [CLUSTER]\033[0m\n" \
-	  } /^[a-zA-Z_.]+:.*?##/ { \
+	  } /^[a-zA-Z0-9_.]+:.*?##/ { \
 	    printf "  \033[36m%-15s\033[0m	%s\n", $$1, $$2 \
 	  } /^##@/ { \
 	    printf "\n\033[1m%s\033[0m\n", substr($$0, 5) \

--- a/components/istio/Makefile
+++ b/components/istio/Makefile
@@ -1,10 +1,9 @@
-##@ Istio Management
-
 # Istio global variable
 ISTIO_HOME 					?= ./components/istio
-ISTIO_CTL						?= $(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl 
+ISTIO_CTL						?= $(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl
 BOOKINFO_NAMESPACE 	?= bookinfo
 
+##@ Istio Management
 # Fetch core istio resources
 .PHONY: istio.fetch
 istio.fetch: ## Fetch core istio resources
@@ -41,17 +40,23 @@ istio.deploy.bookinfo: ## Deploy istio sample bookinfo app
 	kubectl -n bookinfo apply -f samples/bookinfo/networking/bookinfo-gateway.yaml; \
 	bin/istioctl analyze -n bookinfo
 
+##@ Observability
 # Open prometheus dashboard
-.PHONY: istio.view.prometheus
-istio.view.prometheus: ## Open prometheus dashboard
+.PHONY: o11y.prometheus
+o11y.prometheus: ## Open prometheus dashboard
 	$(ISTIO_CTL) dashboard prometheus
 
+# Open grafana dashboard
+.PHONY: o11y.grafana
+o11y.grafana: ## Open grafana dashboard
+	$(ISTIO_CTL) dashboard grafana
+
 # Open kiali dashboard
-.PHONY: istio.view.kiali
-istio.view.kiali: ## Open kiali dashboard 
+.PHONY: o11y.kiali
+o11y.kiali: ## Open kiali dashboard
 	$(ISTIO_CTL) dashboard kiali
 
-# Open grafana dashboard
-.PHONY: istio.view.grafana
-istio.view.grafana: ## Open grafana dashboard
-	$(ISTIO_CTL) dashboard grafana 
+# Open jaeger dashboard
+.PHONY: o11y.jaeger
+o11y.jaeger: ## Open jaeger dashboard
+	$(ISTIO_CTL) dashboard jaeger

--- a/components/istio/Makefile
+++ b/components/istio/Makefile
@@ -1,12 +1,15 @@
 # Istio global variable
 ISTIO_HOME 					?= ./components/istio
 ISTIO_CTL						?= $(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl
+KIALI_USERNAME 			?= admin
+KIALI_PASSWORD 			?= admin
+ISTIO_NAMESPACE			?= istio-system
 BOOKINFO_NAMESPACE 	?= bookinfo
 
 ##@ Istio Management
 # Fetch core istio resources
-.PHONY: istio.fetch
-istio.fetch: ## Fetch core istio resources
+.PHONY: istio.fetch.core
+istio.fetch.core: ## Fetch core istio resources
 ifeq (,$(wildcard $(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)))
 	$(call user_confirm,Istio folder [version: $(ISTIO_VERSION)] not found. Install now)
 	mkdir -p $(ISTIO_HOME)/deploy
@@ -23,7 +26,11 @@ istio.install.default: ## Install istio with default profile and observability s
 		--set addonComponents.kiali.enabled=true \
 		--set addonComponents.prometheus.enabled=true \
 		--set addonComponents.tracing.enabled=true \
+		--set values.kiali.enabled=true \
+    --set "values.kiali.dashboard.jaegerURL=http://jaeger-query:16686" \
+    --set "values.kiali.dashboard.grafanaURL=http://grafana:3000" \
 		--set values.global.controlPlaneSecurityEnabled=true
+	kubectl apply -f $(ISTIO_HOME)/custom/kiali-default-secret.yaml
 
 # Install istio with demo profile
 .PHONY: istio.install.demo
@@ -42,21 +49,21 @@ istio.deploy.bookinfo: ## Deploy istio sample bookinfo app
 
 ##@ Observability
 # Open prometheus dashboard
-.PHONY: o11y.prometheus
-o11y.prometheus: ## Open prometheus dashboard
+.PHONY: o11y.view.prometheus
+o11y.view.prometheus: ## Open prometheus dashboard
 	$(ISTIO_CTL) dashboard prometheus
 
 # Open grafana dashboard
-.PHONY: o11y.grafana
-o11y.grafana: ## Open grafana dashboard
+.PHONY: o11y.view.grafana
+o11y.view.grafana: ## Open grafana dashboard
 	$(ISTIO_CTL) dashboard grafana
 
 # Open kiali dashboard
-.PHONY: o11y.kiali
-o11y.kiali: ## Open kiali dashboard
+.PHONY: o11y.view.kiali
+o11y.view.kiali: ## Open kiali dashboard
 	$(ISTIO_CTL) dashboard kiali
 
 # Open jaeger dashboard
-.PHONY: o11y.jaeger
-o11y.jaeger: ## Open jaeger dashboard
+.PHONY: o11y.view.jaeger
+o11y.view.jaeger: ## Open jaeger dashboard
 	$(ISTIO_CTL) dashboard jaeger

--- a/components/istio/Makefile
+++ b/components/istio/Makefile
@@ -2,6 +2,7 @@
 
 # Istio global variable
 ISTIO_HOME 					?= ./components/istio
+ISTIO_CTL						?= $(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl 
 BOOKINFO_NAMESPACE 	?= bookinfo
 
 # Fetch core istio resources
@@ -15,10 +16,20 @@ else
 	echo "✅ Istio-$(ISTIO_VERSION) is already installed."
 endif
 
+# Install istio with default profile and observability stack
+.PHONY: istio.install.default
+istio.install.default: ## Install istio with default profile and observability stack
+	$(ISTIO_CTL) install \
+		--set addonComponents.grafana.enabled=true \
+		--set addonComponents.kiali.enabled=true \
+		--set addonComponents.prometheus.enabled=true \
+		--set addonComponents.tracing.enabled=true \
+		--set values.global.controlPlaneSecurityEnabled=true
+
 # Install istio with demo profile
 .PHONY: istio.install.demo
 istio.install.demo: ## Install istio with demo profile
-	$(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl install --set profile=demo
+	$(ISTIO_CTL) install --set profile=demo
 
 # Deploy istio sample bookinfo app
 .PHONY: istio.deploy.bookinfo
@@ -33,15 +44,14 @@ istio.deploy.bookinfo: ## Deploy istio sample bookinfo app
 # Open prometheus dashboard
 .PHONY: istio.view.prometheus
 istio.view.prometheus: ## Open prometheus dashboard
-	$(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl dashboard prometheus
+	$(ISTIO_CTL) dashboard prometheus
 
 # Open kiali dashboard
 .PHONY: istio.view.kiali
 istio.view.kiali: ## Open kiali dashboard 
-	$(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl dashboard kiali
+	$(ISTIO_CTL) dashboard kiali
 
 # Open grafana dashboard
 .PHONY: istio.view.grafana
 istio.view.grafana: ## Open grafana dashboard
-	$(ISTIO_HOME)/deploy/istio-$(ISTIO_VERSION)/bin/istioctl dashboard grafana 
-
+	$(ISTIO_CTL) dashboard grafana 

--- a/components/istio/custom/kiali-default-secret.yaml
+++ b/components/istio/custom/kiali-default-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali
+  namespace: istio-system 
+  labels:
+    app: kiali
+type: Opaque
+data:
+  username: YWRtaW4=
+  passphrase: YWRtaW4= 


### PR DESCRIPTION
## Hello Kubernetes Pull Request

### Description
> Brief description of what is being changed and why.

1. Add istio default profile with o11y enabled
2. Move o11y to a different category
3. Add kiali default secret

### Scope of change
> Which resources are included in this pull request?

- [ ] Cluster 
- [x] Components - Istio
- [x] Components - Prometheus
- [x] Components - Grafana 
- [x] Components - Kiali 
- [x] Components - Jaeger
- [ ] Documentation


### Impact
> What happens when this change is applied? What is the scope of the impact?



### Testing
> How was the change tested and what were the results?



### Related changes

**Links to changes in this or other repositories that must be deployed BEFORE
this change is applied**

- PR#

**Links to changes in this or other repositories that must be deployed AFTER
this change is applied**

- PR#



### Delivery
> When required, describe the deployment tasks, schedule and resources needed to deliver this change. Include change request number if scope includes production.



